### PR TITLE
Fix magnifying glass issue in RStudio

### DIFF
--- a/R/plugin-magnifyingGlass.R
+++ b/R/plugin-magnifyingGlass.R
@@ -5,7 +5,7 @@ leafletMagnifyingGlassDependencies <- function() {
       "0.1.0",
       system.file("htmlwidgets/plugins/Leaflet.MagnifyingGlass", package = "leaflet"),
       script = c('leaflet.magnifyingglass.js', 'Control.MagnifyingGlass.js', 'MagnifyingGlass-binding.js'),
-      stylesheet = c('leaflet.magnifyingglass.css', 'Control.MagnifyingGlass.css')
+      stylesheet = c('leaflet.magnifyingglass.css', 'Control.MagnifyingGlass.css', 'MagnifyingGlass-binding.css')
     )
   )
 }

--- a/inst/htmlwidgets/plugins/Leaflet.MagnifyingGlass/MagnifyingGlass-binding.css
+++ b/inst/htmlwidgets/plugins/Leaflet.MagnifyingGlass/MagnifyingGlass-binding.css
@@ -1,0 +1,13 @@
+/* QtWebkit (used by RStudio) doesn't support the -webkit-mask-image workaround
+   that leaflet.magnifyingglass.css uses to make the magnifying glass round.
+   Instead, let it be square in qtwebkit. The qtwebkit class is added in
+   JS if the browser is detected to be QtWebkit. */
+
+.qtwebkit .leaflet-magnifying-glass {
+  border-radius: 0 !important;
+}
+
+.qtwebkit .leaflet-magnifying-glass-webkit {
+  border-radius: 0 !important;
+  -webkit-mask-image: none !important;
+}

--- a/inst/htmlwidgets/plugins/Leaflet.MagnifyingGlass/MagnifyingGlass-binding.js
+++ b/inst/htmlwidgets/plugins/Leaflet.MagnifyingGlass/MagnifyingGlass-binding.js
@@ -1,10 +1,16 @@
 LeafletWidget.methods.addMagnifyingGlass = function(radius, zoomOffset, fixedZoom, fixedPosition,
  latLng, layers, showControlButton, layerId, group) {
   (function() {
+
+    // See comment in MagnifyingGlass-binding.css
+    if (/\bQt\b/.test(window.navigator.userAgent)) {
+      $(this.getContainer()).addClass("qtwebkit");
+    }
+
     if(!layers) {
       layers = [ L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png') ]
     }
-    glass =  L.magnifyingGlass({
+    var glass = L.magnifyingGlass({
         radius: radius,
         zoomOffset: zoomOffset,
         fixedZoom: fixedZoom,
@@ -17,11 +23,11 @@ LeafletWidget.methods.addMagnifyingGlass = function(radius, zoomOffset, fixedZoo
 
     if(showControlButton) {
       if(this.magnifyingGlassControl) {
-        this.magnifyingGlassControl.removeFrom( this );
+        this.magnifyingGlassControl.removeFrom(this);
       }
       this.magnifyingGlassControl = L.control.magnifyingglass(glass,
         {forceSeparateButton: true});
-    this.magnifyingGlassControl.addTo(this);
+      this.magnifyingGlassControl.addTo(this);
     }
   }).call(this);
 };


### PR DESCRIPTION
The change makes the magnifying glass square (only in RStudio). This is the best fix that I could come up with, as QtWebkit (used by RStudio) doesn't support either of the techniques the plugin uses to make the magnifying glass round.